### PR TITLE
Use lookforward for backslash_string end capture

### DIFF
--- a/Syntaxes/LiveScript.tmLanguage
+++ b/Syntaxes/LiveScript.tmLanguage
@@ -798,7 +798,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>([\\)\s,\};\]])</string>
+					<string>(?=[\\)\s,\};\]])</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>0</key>


### PR DESCRIPTION
The terminating character for backslash_string is not part of the string and should not be included in the capture.